### PR TITLE
Nav bars update

### DIFF
--- a/_css/style.css
+++ b/_css/style.css
@@ -406,7 +406,8 @@ h5 a:visited {
 }
 
 body {
-    margin-top: 20px;
+    margin-top: 0px;
+    padding-top: 0px;
 }
 .py-5 {
     padding-top: 3rem !important;

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -18,6 +18,6 @@
     <script src="https://unpkg.com/alpinejs" defer></script>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<header style="position: relative; top: -40px">
+<header style="position: relative">
     {{ insert slidenav.html }} {{ insert nav.html }}
 </header>

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -18,6 +18,6 @@
     <script src="https://unpkg.com/alpinejs" defer></script>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<header style="position: relative">
+<header class="sticky top-0 left-0 w-full z-50">
     {{ insert slidenav.html }} {{ insert nav.html }}
 </header>

--- a/_layout/nav.html
+++ b/_layout/nav.html
@@ -23,7 +23,7 @@
             this.navigationMenu = '';
         }
     }"
-    class="hidden md:relative md:flex z-10 items-center w-full h-24"
+    class="hidden lg:relative lg:flex z-10 items-center w-full h-24"
 >
     <div
         class="relative flex flex-wrap items-start w-full mx-auto font-medium md:items-center justify-between md:h-24"
@@ -267,4 +267,4 @@
         </div>
     </div>
 </nav>
-<div class="hidden md:relative md:flex h-1 my-1 -mx-1 bg-[#00415b]"></div>
+<div class="hidden lg:relative lg:flex h-1 my-1 -mx-1 bg-[#00415b]"></div>

--- a/_layout/nav.html
+++ b/_layout/nav.html
@@ -23,7 +23,7 @@
             this.navigationMenu = '';
         }
     }"
-    class="hidden lg:relative lg:flex z-10 items-center w-full h-24"
+    class="hidden lg:relative lg:flex z-10 items-center w-full h-24 bg-gray-100 dark:bg-gray-800"
 >
     <div
         class="relative flex flex-wrap items-start w-full mx-auto font-medium md:items-center justify-between md:h-24"
@@ -267,4 +267,4 @@
         </div>
     </div>
 </nav>
-<div class="hidden lg:relative lg:flex h-1 my-1 -mx-1 bg-[#00415b]"></div>
+<div class="hidden lg:relative lg:flex h-1 mt-0 my-1 -mx-1 bg-[#00415b]"></div>

--- a/_layout/slidenav.html
+++ b/_layout/slidenav.html
@@ -6,7 +6,7 @@
 >
     <button
         @click="dropdownOpen=true"
-        class="sm:visible md:invisible h-10 px-4 py-2 text-sm font-medium transition-colors bg-white rounded-md hover:bg-neutral-100 active:bg-white focus:bg-white disabled:opacity-50 disabled:pointer-events-none"
+        class="block md:hidden h-16 px-4 py-2 text-sm font-medium transition-colors bg-white rounded-md hover:bg-neutral-100 active:bg-white focus:bg-white disabled:opacity-50 disabled:pointer-events-none"
     >
         <div class="flex space-x-4 w-16">
             <img src="/assets/PresageLogo.png" width="30px" class="w-1/2" />

--- a/_layout/slidenav.html
+++ b/_layout/slidenav.html
@@ -2,13 +2,16 @@
     x-data="{
         dropdownOpen: false
     }"
-    class="relative"
+    class="relative flex justify-end items-center"
 >
     <button
         @click="dropdownOpen=true"
-        class="absolute right-0 sm:visible md:invisible h-10 px-4 py-2 text-sm font-medium transition-colors bg-white rounded-md hover:bg-neutral-100 active:bg-white focus:bg-white disabled:opacity-50 disabled:pointer-events-none"
+        class="sm:visible md:invisible h-10 px-4 py-2 text-sm font-medium transition-colors bg-white rounded-md hover:bg-neutral-100 active:bg-white focus:bg-white disabled:opacity-50 disabled:pointer-events-none"
     >
-        <img src="/assets/burger-menu.svg" width="30px" />
+        <div class="flex space-x-4 w-16">
+            <img src="/assets/PresageLogo.png" width="30px" class="w-1/2" />
+            <img src="/assets/burger-menu.svg" width="30px" class="w-1/2" />
+        </div>
     </button>
 
     <div

--- a/_layout/slidenav.html
+++ b/_layout/slidenav.html
@@ -6,7 +6,7 @@
 >
     <button
         @click="dropdownOpen=true"
-        class="block md:hidden h-16 px-4 py-2 text-sm font-medium transition-colors bg-white rounded-md hover:bg-neutral-100 active:bg-white focus:bg-white disabled:opacity-50 disabled:pointer-events-none"
+        class="block lg:hidden h-16 px-4 py-2 text-sm font-medium transition-colors bg-white rounded-md hover:bg-neutral-100 active:bg-white focus:bg-white disabled:opacity-50 disabled:pointer-events-none"
     >
         <div class="flex space-x-4 w-16">
             <img src="/assets/PresageLogo.png" width="30px" class="w-1/2" />


### PR DESCRIPTION
implements a few changes to the nav bar
- fixes positioning hack, so now the nav bar is always correctly positioned
- adds presage logo next to the hamburger icon in "small view" 
- menu stays with you while you scroll
- uses "small menu" below `lg` rather than below `md` since the navbar would get stacked between those sizes 