### PR TITLE
actions/cache updated to v4

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
       # cache for speed
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             __cache


### PR DESCRIPTION
Getting this error with github actions:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions.
```
So, updated actions/cache updated to v4